### PR TITLE
Fix tx "to" values to be more accurate when not calling a contract

### DIFF
--- a/src/near_to_eth_objects.js
+++ b/src/near_to_eth_objects.js
@@ -73,7 +73,7 @@ nearToEth.transactionObj = async function(tx, txIndex) {
         from: sender,
 
         // DATA 20 bytes - address of the receiver
-        to: `0x${destination}`,
+        to: utils.include0x(destination),
 
         // QUANTITY - integer of the current gas price in wei
         // TODO: This will break with big numbers?
@@ -271,12 +271,20 @@ nearToEth.transactionReceiptObj = function(block, nearTxObj, nearTxObjIndex, acc
     }
 
     // if it's a call, get the destination address
-    if (functionCall && functionCall.method_name == 'call_contract') {
-      const args = JSON.parse(utils.base64ToString(functionCall.args));
-      destination = args.contract_address;
-    } else {
-        const receiver = utils.nearAccountToEvmAddress(transaction.receiver_id);
-        destination = receiver;
+    if (functionCall) {
+        const args = JSON.parse(utils.base64ToString(functionCall.args));
+        switch (functionCall.method_name) {
+            case 'call_contract':
+                destination = args.contract_address;
+                break;
+            case 'add_near':
+                destination = utils.nearAccountToEvmAddress(transaction.signer_id);
+                break;
+            case 'move_funds_to_evm_address':
+                destination = args.address;
+                break;
+            default:
+        }       const receiver = utils.nearAccountToEvmAddress(transaction.receiver_id);
     }
 
     // TODO: translate logs
@@ -299,7 +307,7 @@ nearToEth.transactionReceiptObj = function(block, nearTxObj, nearTxObjIndex, acc
         from: utils.nearAccountToEvmAddress(transaction.signer_id),
 
         // DATA address of the receiver, null when it's a contract creation tx
-        to: destination ? `0x${destination}` : null,
+        to: destination ? utils.include0x(destination) : null,
 
         // DATA The contract address created, if the transaction was a contract
         // creation, otherwise null

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,6 +27,21 @@ utils.remove0x = function(value) {
 };
 
 /**
+ * Add 0x if not prepended
+ * @param {String} value value to check and modify
+ * @return {String} string with 0x
+ */
+utils.include0x = function(value) {
+    assert(typeof value === 'string', 'include0x: must pass in string');
+
+    if (value.slice(0, 2) === '0x') {
+        return value
+    } else {
+        return `0x${value}`;
+    }
+};
+
+/**
  * Checks if string is hex
  * @param {String} value value to check
  * @returns {Boolean} true if value is hex, false if not

--- a/test/near_provider.test.js
+++ b/test/near_provider.test.js
@@ -324,6 +324,7 @@ describe('\n---- PROVIDER ----', () => {
                 });
                 let newBalance = parseInt(await web.eth.getBalance(from, 'latest'))
 
+                expect(addNear.to).toStrictEqual(from)
                 expect(newBalance).toStrictEqual(prevBalance + value);
             }));
 
@@ -351,6 +352,7 @@ describe('\n---- PROVIDER ----', () => {
                 let newFromBalance = parseInt(await web.eth.getBalance(from, 'latest'))
                 let newToBalance = parseInt(await web.eth.getBalance(to, 'latest'))
 
+                expect(sendResult.to).toStrictEqual(to)
                 expect(newFromBalance).toStrictEqual(prevFromBalance - value);
                 expect(newToBalance).toStrictEqual(prevToBalance + value);
             }));

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -20,6 +20,31 @@ describe('utils', () => {
         });
     });
 
+    describe('#include0x', () => {
+        test('adds 0x to value without 0x', () => {
+            const value = '0000';
+            const result = utils.include0x(value);
+            expect(result).toEqual('0x0000');
+        });
+
+        test('does not add extra 0x if value already contains 0x', () => {
+            const value = '0x0000';
+            const result = utils.include0x(value);
+            expect(result).toEqual('0x0000');
+        });
+
+        test('returns string', () => {
+            const value = '0x0000';
+            const result = utils.include0x(value);
+            expect(typeof result).toEqual('string');
+        });
+
+        test('errors if arg is not string', () => {
+            const value = 10;
+            expect(() => utils.include0x(value)).toThrow();
+        });
+    });
+
     describe('#isHex', () => {
         test('returns true if string is hex', () => {
             const value = '0x0000';


### PR DESCRIPTION
Originally attempting to fix: https://github.com/nearprotocol/near-web3-provider/issues/14
However our tests never call `transactionObj` without all 0 value parameters. 
So, this PR makes the same fix for `transactionReceiptObj` which gets called very often.