### PR TITLE
Must be able to accept both near and eth formatted txHash/accountID

### DIFF
--- a/src/near_to_eth_objects.js
+++ b/src/near_to_eth_objects.js
@@ -52,6 +52,7 @@ nearToEth.transactionObj = async function(tx, txIndex) {
     const { transaction_outcome, transaction } = tx;
 
     const functionCall = transaction.actions[0].FunctionCall;
+
     // if it's a call, get the destination address
     if (functionCall && functionCall.method_name == 'call_contract') {
       const args = JSON.parse(utils.base64ToString(functionCall.args));
@@ -73,14 +74,14 @@ nearToEth.transactionObj = async function(tx, txIndex) {
         from: sender,
 
         // DATA 20 bytes - address of the receiver
-        to: utils.include0x(destination),
+        to: destination ? utils.include0x(destination) : null,
 
         // QUANTITY - integer of the current gas price in wei
         // TODO: This will break with big numbers?
         gasPrice: utils.decToHex(parseInt(tx.gas_price)),
 
         // DATA - the data sent along with the transaction
-        input: '0x' + data ? data : '',
+        input: data ? utils.include0x(data) : '',
 
         // DATA 32 bytes - hash of the block where this transaction was in
         blockHash: transaction_outcome.block_hash,

--- a/src/utils.js
+++ b/src/utils.js
@@ -198,14 +198,39 @@ utils.convertTimestamp = function(value) {
 utils.getTxHashAndAccountId = function(value) {
     if (value.includes(':')) {
         // Split value into txHash and accountId
-        const [txHash, accountId] = value.split(':');
-
+        const [value1, value2] = value.split(':');
+        const { txHash, accountId } = distinguishTxValues(value1, value2)
         // Return object for convenience so we don't need to keep track of index order
         return { txHash, accountId };
     } else {
         return { txHash: value, accountId: '' };
     }
 };
+
+const distinguishTxValues = function(value1, value2) {
+    let txHash, accountId;
+
+    if (isValidAccountId(value1) && hasOnlyAlphanumeric(value2)) {
+        accountId = value1;
+        txHash = value2;
+    } else if (isValidAccountId(value2) && hasOnlyAlphanumeric(value1))  {
+        accountId = value2;
+        txHash = value1;
+    } else {
+        throw new TypeError(`Invalid txHash: ${value1}:${value2}`);
+    }
+
+    return { txHash, accountId }
+}
+
+const isValidAccountId = function(value) {
+    // has a period or is all lowercase
+    return value.includes(".") || /[A-Z]/.test(value) == false
+}
+
+const hasOnlyAlphanumeric = function(value) {
+    return /^[a-z0-9]+$/i.test(value)
+}
 
 /**
  * Converts a Near account ID into the corresponding ETH address

--- a/test/near_provider.test.js
+++ b/test/near_provider.test.js
@@ -570,14 +570,12 @@ describe('\n---- PROVIDER ----', () => {
                 expect(tx.hash).toStrictEqual(transactionHash);
             }));
 
-
             test('returns transaction from block number', withWeb3(async (web) => {
                 const tx = await web.eth.getTransactionFromBlock(blockWithTxsNumber, txIndex);
                 expect(typeof tx).toBe('object');
                 expect(typeof tx.hash).toBe('string');
                 expect(tx.hash).toStrictEqual(transactionHash);
             }));
-
 
             test('returns transaction from string - latest', withWeb3(async (web) => {
                 const tx = await web.eth.getTransactionFromBlock('latest', txIndex);
@@ -606,6 +604,7 @@ describe('\n---- PROVIDER ----', () => {
             test('gets transaction receipt', withWeb3(async (web) => {
                 try {
                     const txResult = await createEvmTransaction(web);
+                    console.log("txResult.transactionHash ", txResult.transactionHash)
                     const txReceipt = await web.eth.getTransactionReceipt(txResult.transactionHash);
 
                     expect(typeof transactionHash).toBeTruthy();
@@ -617,12 +616,14 @@ describe('\n---- PROVIDER ----', () => {
             }));
 
             test('errors if not a real txhash', withWeb3(async (web) => {
+                const notRealHash = '9Y9SUcuLRX1afHsyocHiryPQvqAujrJqugy4WgjfXGiw';
+                const badInput = `${notRealHash}:hello`;
+
                 try {
-                    const badHash = 'whatsuppppp:hello';
-                    await web.eth.getTransactionReceipt(badHash);
+                    await web.eth.getTransactionReceipt(badInput);
                 } catch (e) {
                     expect(e).toBeTruthy();
-                    expect(e.message).toEqual('[-32602] Invalid params: Failed parsing args: incorrect length for hash');
+                    expect(e.message).toEqual(`[-32000] Server error: Transaction ${notRealHash} doesn't exist`);
                 }
             }));
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -94,11 +94,12 @@ describe('utils', () => {
 
     describe('#getTxHashAndAccountId', () => {
         test('splits txHash and accountId', () => {
-            const txHashAndAccountId = '0x0000:accountId';
+            const base58Hash = 'ByGDjvYxVZDxv69c86tFCFDRnJqK4zvj9uz4QVR4bH4P'
+            const txHashAndAccountId = `${base58Hash}:accountid`;
             const result = utils.getTxHashAndAccountId(txHashAndAccountId);
             expect(typeof result).toEqual('object');
-            expect(result.txHash).toEqual('0x0000');
-            expect(result.accountId).toEqual('accountId');
+            expect(result.txHash).toEqual(base58Hash);
+            expect(result.accountId).toEqual('accountid');
         });
     });
 


### PR DESCRIPTION
In relation to Issue https://github.com/nearprotocol/near-web3-provider/issues/9.

This.is.hacky.

Storing things under the Near format `accountId:txHash`  (instead of reversed) has been difficult.
web3 callback hooks that call through to our provider from the web3 library have this field with the ETH format. But when we ourselves call our provider, we'll be wanting to provide the Near format. Our provider needs to be able to accept both. 

However, there's an edgecase in my conditionals to distinguish between the two: If a tx hash has no capital letters w/ an accountID that is purely alphanumeric this could fail.

1. We can opt to just go with the ETH format if we're dealing in Solidity. Forking web3 doesn't seem worth it to me.
2. Am I missing something? Is this our own app reversing the order somewhere that I haven't located? 