### PR TITLE
getTransaction object mirrors ethereum's getTransaction

### DIFF
--- a/src/near_to_eth_objects.js
+++ b/src/near_to_eth_objects.js
@@ -36,101 +36,6 @@ nearToEth.syncObj = function(syncInfo) {
 };
 
 /**
- * Maps NEAR Transaction FROM A TX QUERY to ETH Transaction Object
- * @param {Object} 		tx NEAR transaction
- * @param {Number}		txIndex	txIndex
- * @returns {Object} returns ETH transaction object
- *
- * @example nearToEth.transactionObject(tx, txIndex)
- */
-nearToEth.transactionObj = async function(tx, txIndex) {
-    assert(typeof tx === 'object' && tx.hash,
-        'nearToEth.transactionObj: must pass in tx object');
-
-    let destination = null;
-    let data = null;
-    let value = null;
-    const { transaction_outcome, transaction } = tx;
-
-    const functionCall = transaction.actions[0].FunctionCall;
-    if (functionCall) {
-        const args = JSON.parse(utils.base64ToString(functionCall.args));
-        switch (functionCall.method_name) {
-            case 'call_contract':
-                destination = args.contract_address;
-                data = args.encoded_input;
-                break;
-            case 'deploy_code':
-                data = args.bytecode;
-                break;
-            case 'add_near':
-                destination = utils.nearAccountToEvmAddress(transaction.signer_id);
-                break;
-            case 'move_funds_to_evm_address':
-                destination = args.address;
-                value = parseInt(args.amount)
-                break;
-        }
-    }
-
-    const sender = utils.nearAccountToEvmAddress(transaction.signer_id);
-
-    if (value == null) {
-        value = transaction.actions.map(v => {
-            const k = Object.keys(v)[0];
-            return parseInt(v[k].deposit, 10);
-        }).reduce((a, b) => a + b);
-    }
-
-    const obj = {
-        // DATA 20 bytes - address of the sender
-        // from: sender,
-        from: sender,
-
-        // DATA 20 bytes - address of the receiver
-        to: destination ? utils.include0x(destination) : null,
-
-        // QUANTITY - integer of the current gas price in wei
-        // TODO: This will break with big numbers?
-        gasPrice: utils.decToHex(parseInt(tx.gas_price)),
-
-        // DATA - the data sent along with the transaction
-        input: data ? utils.include0x(data) : '',
-
-        // DATA 32 bytes - hash of the block where this transaction was in
-        blockHash: utils.base58ToHex(transaction_outcome.block_hash),
-
-        // QUANTITY block number where this transaction was in
-        blockNumber: utils.decToHex(tx.block_height),
-
-        // QUANTITY gas provided by the sender
-        gas: utils.decToHex(transaction_outcome.outcome.gas_burnt),
-
-        // DATA 32 bytes - hash of the transaction
-        hash: `${transaction.hash}:${transaction.signer_id}`,
-
-        // QUANTITY - the number of txs made by the sender prior to this one
-        nonce: utils.decToHex(tx.nonce),
-
-        // QUANTITY - integer of the tx's index position in the block
-        transactionIndex: utils.decToHex(txIndex),
-
-        // QUANTITY - value transferred in wei (yoctoNEAR)
-        value: utils.decToHex(value),
-
-        /** ------------ UNSUPPORTED/FALSY VALUES --------- */
-        // QUANTITY - ECDSA recovery id
-        v: '0x0',
-        // QUANTITY - ECDSA signature r
-        r: '0x0',
-        // QUANTITY - ECDSA signature s
-        s: '0x0'
-    };
-
-    return obj;
-};
-
-/**
  * Get the total gas used. gas_used is listed on each chunk
  */
 // TODO: Is this chunks.gas_used or accumulated gas_burnt for each tx?
@@ -263,6 +168,56 @@ nearToEth.blockObj = async function(block, returnTxObjects, nearProvider) {
 };
 
 /**
+ * Maps NEAR Transaction FROM A TX QUERY to ETH Transaction Object
+ * @param {Object} 		tx NEAR transaction
+ * @param {Number}		txIndex	txIndex
+ * @returns {Object} returns ETH transaction object
+ *
+ * @example nearToEth.transactionObject(tx, txIndex)
+ */
+nearToEth.transactionObj = async function(tx, txIndex) {
+    assert(typeof tx === 'object' && tx.hash,
+        'nearToEth.transactionObj: must pass in tx object');
+
+    const { transaction_outcome, transaction } = tx;
+    let sharedParams = processSharedParams(
+        transaction,
+        transaction_outcome.block_hash,
+        tx.block_height,
+        transaction_outcome.outcome.gas_burnt,
+        txIndex
+    )
+    if (sharedParams.value == null) {
+        sharedParams.value = transaction.actions.map(v => {
+            const k = Object.keys(v)[0];
+            return parseInt(v[k].deposit, 10);
+        }).reduce((a, b) => a + b);
+    }
+
+    return {
+        // DATA 32 bytes - hash of the transaction
+        hash: `${transaction.hash}:${transaction.signer_id}`,
+
+        // QUANTITY - the number of txs made by the sender prior to this one
+        nonce: utils.decToHex(tx.nonce),
+
+        ...sharedParams,
+
+        // QUANTITY - integer of the current gas price in wei
+        // TODO: This will break with big numbers?
+        gasPrice: utils.decToHex(parseInt(tx.gas_price)),
+
+        /** ------------ UNSUPPORTED/FALSY VALUES --------- */
+        // QUANTITY - ECDSA recovery id
+        v: '0x0',
+        // QUANTITY - ECDSA signature r
+        r: '0x0',
+        // QUANTITY - ECDSA signature s
+        s: '0x0',
+    };
+};
+
+/**
  * Maps NEAR transaction to ETH Transaction Receipt Object
  * @param {Object} block NEAR block
  * @param {Object} nearTxObj NEAR transaction object
@@ -271,8 +226,8 @@ nearToEth.blockObj = async function(block, returnTxObjects, nearProvider) {
  */
 nearToEth.transactionReceiptObj = function(block, nearTxObj, nearTxObjIndex, accountId) {
     let contractAddress = null;
-    let destination = null;
 
+    const isReceipt = true;
     const { transaction, transaction_outcome, status } = nearTxObj;
     const responseData = utils.base64ToString(status.SuccessValue);
     const functionCall = transaction.actions[0].FunctionCall;
@@ -285,50 +240,26 @@ nearToEth.transactionReceiptObj = function(block, nearTxObj, nearTxObjIndex, acc
       }
     }
 
-    // if it's a call, get the destination address
-    if (functionCall) {
-        const args = JSON.parse(utils.base64ToString(functionCall.args));
-        switch (functionCall.method_name) {
-            case 'call_contract':
-                destination = args.contract_address;
-                break;
-            case 'add_near':
-                destination = utils.nearAccountToEvmAddress(transaction.signer_id);
-                break;
-            case 'move_funds_to_evm_address':
-                destination = args.address;
-                break;
-        }
-    }
-
     // TODO: translate logs
     const { gas_burnt, logs } = transaction_outcome.outcome;
+    let sharedParams = processSharedParams(
+        transaction,
+        block.header.hash,
+        block.header.height,
+        transaction_outcome.outcome.gas_burnt,
+        nearTxObjIndex,
+        isReceipt,
+    )
 
     return {
         // DATA Hash of the transaction
         transactionHash: `${transaction.hash}:${accountId}`,
 
-        // QUANTITY integer of the transaction's position in the block
-        transactionIndex: nearTxObjIndex,
-
-        // DATA hash of the block where this transaction was in
-        blockNumber: utils.decToHex(block.header.height),
-
-        // QUANTITY block number where this transaction was in
-        blockHash: utils.base58ToHex(block.header.hash),
-
-        // DATA address of the sender
-        from: utils.nearAccountToEvmAddress(transaction.signer_id),
-
-        // DATA address of the receiver, null when it's a contract creation tx
-        to: destination ? utils.include0x(destination) : null,
+        ...sharedParams,
 
         // DATA The contract address created, if the transaction was a contract
         // creation, otherwise null
         contractAddress: contractAddress,
-
-        // QUANTITY The amount of gas used by this specific transaction alone
-        gasUsed: utils.decToHex(gas_burnt),
 
         // ARRAY Array of log objects, which this transaction generated
         logs: logs,
@@ -343,12 +274,73 @@ nearToEth.transactionReceiptObj = function(block, nearTxObj, nearTxObjIndex, acc
         /**------------UNSUPPORTED/NULL VALUES--------- */
 
         // DATA Bloom filter for light clients to quickly retrieve related logs
-        logsBloom: `0x${'00'.repeat(256)}`
+        logsBloom: `0x${'00'.repeat(256)}`,
 
         // DATA 32 bytes of post-transaction stateroot (pre Byzantium)
         // txReceipt will return EITHER status or root. Always returns status.
         // root: '0x'
     };
 };
+
+function processSharedParams(transaction, blockHash, blockHeight, gasBurnt, txIndex, isReceipt = false) {
+    const gas = utils.decToHex(gasBurnt)
+    let destination = null;
+    let data = null;
+    let value = null;
+
+    // function specific parameters
+    const functionCall = transaction.actions[0].FunctionCall;
+    if (functionCall) {
+        const args = JSON.parse(utils.base64ToString(functionCall.args));
+        switch (functionCall.method_name) {
+            case 'call_contract':
+                destination = args.contract_address;
+                data = args.encoded_input;
+                break;
+            case 'deploy_code':
+                data = args.bytecode;
+                break;
+            case 'add_near':
+                destination = utils.nearAccountToEvmAddress(transaction.signer_id);
+                break;
+            case 'move_funds_to_evm_address':
+                destination = args.address;
+                value = parseInt(args.amount)
+                break;
+        }
+    }
+
+    let obj =  {
+        // DATA hash of the block where this transaction was in
+        blockHash: utils.base58ToHex(blockHash),
+        // QUANTITY block number where this transaction was in
+        blockNumber: utils.decToHex(blockHeight),
+        // QUANTITY integer of the transaction's position in the block
+        transactionIndex: txIndex,
+        // DATA address of the sender
+        from: utils.nearAccountToEvmAddress(transaction.signer_id),
+        // DATA address of the receiver, null when it's a contract creation tx
+        to: destination ? utils.include0x(destination) : null,
+    }
+
+    let additionalParams
+    if (isReceipt) {
+        additionalParams = {
+            // QUANTITY The amount of gas used by this specific transaction alone
+            gasUsed: gas
+        }
+    } else {
+        additionalParams = {
+            // QUANTITY The amount of gas used by this specific transaction alone
+            gas,
+            // QUANTITY - value transferred in wei (yoctoNEAR)
+            value: value ? utils.decToHex(value) : null,
+             // DATA - the data sent along with the transaction
+            input: data ? utils.include0x(data) : '',
+        }
+    }
+
+    return { ...obj, ...additionalParams }
+}
 
 module.exports = nearToEth;

--- a/src/near_to_eth_objects.js
+++ b/src/near_to_eth_objects.js
@@ -187,7 +187,7 @@ nearToEth.transactionObj = async function(tx, txIndex) {
         transaction_outcome.outcome.gas_burnt,
         txIndex
     )
-    if (sharedParams.value == null) {
+    if (sharedParams.value === null) {
         sharedParams.value = transaction.actions.map(v => {
             const k = Object.keys(v)[0];
             return parseInt(v[k].deposit, 10);

--- a/test/near_provider.test.js
+++ b/test/near_provider.test.js
@@ -445,7 +445,7 @@ describe('\n---- PROVIDER ----', () => {
                     // TODO: test nonce: see issue #27 https://github.com/nearprotocol/near-web3-provider/issues/27
                     const tx = await web.eth.getTransaction(transactionHash);
                     expect(tx.blockHash).toStrictEqual(blockWithTxsHash)
-                    expect(isHex(tx.blockHash)).toBeTruthy()
+                    expect(utils.isHex(tx.blockHash)).toBeTruthy()
                     expect(tx.blockNumber).toStrictEqual(blockWithTxsNumber)
                     expect(tx.transactionIndex).toStrictEqual(txIndex)
                     expect(tx.hash).toStrictEqual(transactionHash)
@@ -475,7 +475,7 @@ describe('\n---- PROVIDER ----', () => {
                     // TODO: test nonce: see issue #27 https://github.com/nearprotocol/near-web3-provider/issues/27
                     const tx = await web.eth.getTransaction(txHash);
                     expect(tx.blockHash).toStrictEqual(txReceipt.blockHash)
-                    expect(isHex(tx.blockHash)).toBeTruthy()
+                    expect(utils.isHex(tx.blockHash)).toBeTruthy()
                     expect(tx.blockNumber).toStrictEqual(txReceipt.blockNumber)
                     expect(tx.transactionIndex).toStrictEqual(txReceipt.transactionIndex)
                     expect(tx.hash).toStrictEqual(txHash)
@@ -516,7 +516,7 @@ describe('\n---- PROVIDER ----', () => {
                     // TODO: test nonce: see issue #27 https://github.com/nearprotocol/near-web3-provider/issues/27
                     const tx = await web.eth.getTransaction(addNearReceipt.transactionHash);
                     expect(tx.blockHash).toStrictEqual(addNearReceipt.blockHash)
-                    expect(isHex(tx.blockHash)).toBeTruthy()
+                    expect(utils.isHex(tx.blockHash)).toBeTruthy()
                     expect(tx.blockNumber).toStrictEqual(addNearReceipt.blockNumber)
                     expect(tx.transactionIndex).toStrictEqual(addNearReceipt.transactionIndex)
                     expect(tx.hash).toStrictEqual(addNearReceipt.transactionHash)
@@ -530,7 +530,7 @@ describe('\n---- PROVIDER ----', () => {
                     // TODO: test nonce: see issue #27 https://github.com/nearprotocol/near-web3-provider/issues/27
                     const tx = await web.eth.getTransaction(transferReceipt.transactionHash);
                     expect(tx.blockHash).toStrictEqual(transferReceipt.blockHash)
-                    expect(isHex(tx.blockHash)).toBeTruthy()
+                    expect(utils.isHex(tx.blockHash)).toBeTruthy()
                     expect(tx.blockNumber).toStrictEqual(transferReceipt.blockNumber)
                     expect(tx.transactionIndex).toStrictEqual(transferReceipt.transactionIndex)
                     expect(tx.hash).toStrictEqual(transferReceipt.transactionHash)
@@ -758,9 +758,4 @@ async function getLatestBlockInfo () {
 
 async function waitForABlock () {
     return await new Promise((r) => setTimeout(r, 1000));
-}
-
-function isHex(h) {
-    var re = /^0x[0-9A-Fa-f]{12}/g;
-    return re.test(h)
 }

--- a/test/near_provider.test.js
+++ b/test/near_provider.test.js
@@ -5,6 +5,7 @@
 
 const fs = require('fs');
 const web3 = require('web3');
+const bn = web3.utils.BN
 const nearlib = require('near-api-js');
 const utils = require('../src/utils');
 const { NearProvider } = require('../src/index');
@@ -404,6 +405,9 @@ describe('\n---- PROVIDER ----', () => {
         let txIndex;
         let blockWithTxsHash;
         let blockWithTxsNumber;
+        let zombieCode
+        let zombieAddress
+        const value = 10
         const base58TxHash = 'ByGDjvYxVZDxv69c86tFCFDRnJqK4zvj9uz4QVR4bH4P';
 
         beforeAll(withWeb3(async (web) => {
@@ -411,19 +415,132 @@ describe('\n---- PROVIDER ----', () => {
             blockHash = newBlock.blockHash;
             blockHeight = newBlock.blockHeight;
 
-            txResult = await web.eth.sendTransaction({
-                from: '00'.repeat(20),
-                to: '00'.repeat(20),
-                value: 0,
+            zombieCode = fs.readFileSync(zombieCodeFile).toString();
+            const txResult = await web.eth.sendTransaction({
+                from: `0x${'00'.repeat(20)}`,
+                to: undefined,
+                value,
                 gas: 0,
-                data: '0x00'
+                data: `0x${zombieCode}`
             });
 
+            zombieAddress = txResult.contractAddress;
             transactionHash = txResult.transactionHash;
             txIndex = txResult.transactionIndex;
             blockWithTxsHash = txResult.blockHash;
             blockWithTxsNumber = txResult.blockNumber;
         }));
+
+        describe('getTransaction | eth_getTransactionByHash', () => {
+            test('fails to get non-existant transactions', withWeb3(async(web) => {
+                try {
+                    await web.eth.getTransaction(`${base58TxHash}:${ACCOUNT_ID}`);
+                } catch (e) {
+                    expect(e).toBeDefined();
+                }
+            }));
+
+            describe('for contract creation transaction', () => {
+                test('has corrent parameters', withWeb3(async(web) => {
+                    // TODO: test nonce: see issue #27 https://github.com/nearprotocol/near-web3-provider/issues/27
+                    const tx = await web.eth.getTransaction(transactionHash);
+                    expect(tx.blockHash).toStrictEqual(blockWithTxsHash)
+                    expect(isHex(tx.blockHash)).toBeTruthy()
+                    expect(tx.blockNumber).toStrictEqual(blockWithTxsNumber)
+                    expect(tx.transactionIndex).toStrictEqual(txIndex)
+                    expect(tx.hash).toStrictEqual(transactionHash)
+                    expect(tx.from.toLowerCase()).toStrictEqual(web._provider.accountEvmAddress.toLowerCase())
+                    expect(tx.to).toBeNull()
+                    expect(tx.input).toStrictEqual("0x" + zombieCode)
+                    expect(parseInt(tx.value)).toStrictEqual(value)
+                }));
+            });
+
+            describe('for contract interaction transaction', () => {
+                let txHash
+                let encoded_call
+                let txReceipt
+
+                beforeAll(withWeb3(async (web) => {
+                    let zombieABI = JSON.parse(fs.readFileSync(zombieABIFile).toString());
+                    let zombies = new web.eth.Contract(zombieABI, zombieAddress);
+                    txReceipt = await zombies.methods.createRandomZombie('george')
+                        .send({from: web._provider.accountEvmAddress});
+
+                    txHash = txReceipt.transactionHash
+                    encoded_call = zombies.methods.createRandomZombie('george').encodeABI()
+                }))
+
+                test('has correct parameters', withWeb3(async(web) => {
+                    // TODO: test nonce: see issue #27 https://github.com/nearprotocol/near-web3-provider/issues/27
+                    const tx = await web.eth.getTransaction(txHash);
+                    expect(tx.blockHash).toStrictEqual(txReceipt.blockHash)
+                    expect(isHex(tx.blockHash)).toBeTruthy()
+                    expect(tx.blockNumber).toStrictEqual(txReceipt.blockNumber)
+                    expect(tx.transactionIndex).toStrictEqual(txReceipt.transactionIndex)
+                    expect(tx.hash).toStrictEqual(txHash)
+                    expect(tx.from.toLowerCase()).toStrictEqual(web._provider.accountEvmAddress.toLowerCase())
+                    expect(tx.to).toStrictEqual(zombieAddress)
+                    expect(tx.input).toStrictEqual(encoded_call)
+                    expect(parseInt(tx.value)).toStrictEqual(0)
+                }));
+            });
+
+            describe('for simple transfer transactions', () => {
+                let addNearReceipt
+                let transferReceipt
+                let to
+                let from
+                let value = 5
+
+                beforeAll(withWeb3(async (web) => {
+                    from = web._provider.accountEvmAddress;
+                    to = utils.nearAccountToEvmAddress("random")
+
+                    addNearReceipt = await web.eth.sendTransaction({
+                        from,
+                        to: from,
+                        value: value * 2,
+                        gas: 0
+                    });
+
+                    transferReceipt = await web.eth.sendTransaction({
+                        from,
+                        to,
+                        value,
+                        gas: 0
+                    });
+                }))
+
+                test('transaction has correct parameters for addNear from near account to evm account', withWeb3(async(web) => {
+                    // TODO: test nonce: see issue #27 https://github.com/nearprotocol/near-web3-provider/issues/27
+                    const tx = await web.eth.getTransaction(addNearReceipt.transactionHash);
+                    expect(tx.blockHash).toStrictEqual(addNearReceipt.blockHash)
+                    expect(isHex(tx.blockHash)).toBeTruthy()
+                    expect(tx.blockNumber).toStrictEqual(addNearReceipt.blockNumber)
+                    expect(tx.transactionIndex).toStrictEqual(addNearReceipt.transactionIndex)
+                    expect(tx.hash).toStrictEqual(addNearReceipt.transactionHash)
+                    expect(tx.from.toLowerCase()).toStrictEqual(from.toLowerCase())
+                    expect(tx.to.toLowerCase()).toStrictEqual(from.toLowerCase())
+                    expect(tx.input).toStrictEqual('')
+                    expect(parseInt(tx.value)).toStrictEqual(value * 2)
+                }))
+
+                test('transaction has correct parameters for transfers between evm addrs', withWeb3(async(web) => {
+                    // TODO: test nonce: see issue #27 https://github.com/nearprotocol/near-web3-provider/issues/27
+                    const tx = await web.eth.getTransaction(transferReceipt.transactionHash);
+                    expect(tx.blockHash).toStrictEqual(transferReceipt.blockHash)
+                    expect(isHex(tx.blockHash)).toBeTruthy()
+                    expect(tx.blockNumber).toStrictEqual(transferReceipt.blockNumber)
+                    expect(tx.transactionIndex).toStrictEqual(transferReceipt.transactionIndex)
+                    expect(tx.hash).toStrictEqual(transferReceipt.transactionHash)
+                    expect(tx.from.toLowerCase()).toStrictEqual(from.toLowerCase())
+                    expect(tx.to.toLowerCase()).toStrictEqual(to.toLowerCase())
+                    expect(tx.input).toStrictEqual('')
+                    expect(parseInt(tx.value)).toStrictEqual(value)
+                }))
+            })
+        });
 
         describe('getBlockNumber | eth_blockNumber', () => {
             test('returns the most recent blockNumber', withWeb3(async (web) => {
@@ -538,27 +655,6 @@ describe('\n---- PROVIDER ----', () => {
             }));
         });
 
-        describe('getTransaction | eth_getTransactionByHash', () => {
-            test('fails to get non-existant transactions', withWeb3(async(web) => {
-                try {
-                    await web.eth.getTransaction(`${base58TxHash}:${ACCOUNT_ID}`);
-                } catch (e) {
-                    expect(e).toBeDefined();
-                }
-            }));
-
-            test('it gets a transaction by hash', withWeb3(async(web) => {
-                try {
-                    const tx = await web.eth.getTransaction(transactionHash);
-                    expect(tx).toBeDefined();
-                    expect(tx.contractAddress).toBeNull();
-                    expect(tx.status).toBe(true);
-                } catch (e) {
-                    return e;
-                }
-            }));
-        });
-
         describe(`getTransactionFromBlock |
             eth_getTransactionByBlockHashAndIndex,
             eth_getTransactionByBlockNumberAndIndex`, () => {
@@ -662,4 +758,9 @@ async function getLatestBlockInfo () {
 
 async function waitForABlock () {
     return await new Promise((r) => setTimeout(r, 1000));
+}
+
+function isHex(h) {
+    var re = /^0x[0-9A-Fa-f]{12}/g;
+    return re.test(h)
 }


### PR DESCRIPTION
Best reviewed on a per commit basis. (less confusing)

* TransactionObj has correct output for all valid function types deploy/functionCall/Transfers
* DRY up `TransactionObj` and `ReceiptTransactionObj` which have much of the same content
